### PR TITLE
Rename Director to Directord

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.eggs
 *.pyc
 .coverage
+.vscode

--- a/README.rst
+++ b/README.rst
@@ -22,10 +22,10 @@ Example invocation (from folder)
             --roles-file examples/directord/roles.yaml \
             --debug
 
-Example director execution
+Example directord execution
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This is an example that uses [https://github.com/cloudnull/director] to setup
+This is an example that uses [https://github.com/cloudnull/directord] to setup
 an instance of keystone. The below bit of code assumes 4 nodes available
 with a stack user that can been connected to via ssh from the user running
 the bash script.
@@ -37,12 +37,9 @@ the bash script.
     virtualenv ~/test-venv
     source ~/test-venv/bin/activate
 
-    git clone https://github.com/cloudnull/directord
     git clone https://github.com/mwhahaha/task-core
 
-    pushd directord
-    pip install .
-    popd
+    pip install directord
 
     pushd task-core
     pip install -r requirements.txt
@@ -72,7 +69,7 @@ the bash script.
       - host: 192.168.24.5
     EOF
 
-    pushd director
+    pushd directord
     # needed to get the share files in place
     pip install .
     directord bootstrap --catalog $HOME/catalog --catalog tools/directord-bootstrap-catalog.yaml
@@ -91,8 +88,8 @@ the bash script.
     EOF
 
     task-core \
-      -s task-core/examples/director/services/ \
+      -s task-core/examples/directord/services/ \
       -i $HOME/inventory.yaml \
-      -r task-core/examples/director/roles.yaml
+      -r task-core/examples/directord/roles.yaml
 
     ssh standalone-1 openstack --os-auth-url http://standalone-1:5000/v3 --os-user-domain-name default --os-username admin --os-password keystone token issue

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-# Director is currently unpublished, this pulls in director from git sources
--e git+https://github.com/cloudnull/directord.git@main#egg=directord
+directord
 
 pbr!=2.1.0,>=2.0.0
 taskflow

--- a/task_core/cmd.py
+++ b/task_core/cmd.py
@@ -111,7 +111,7 @@ def main():
     add_services_to_flow(flow, services)
 
     LOG.info("Running...")
-    # NOTE(mwhahaha): director doesn't workw ith parallel, use serial for now
+    # NOTE(mwhahaha): directord doesn't work with parallel, use serial for now
     result = engines.run(flow, engine="serial")
     LOG.info("Done...")
     pprint.pprint(result)

--- a/task_core/tasks.py
+++ b/task_core/tasks.py
@@ -91,14 +91,14 @@ class DirectordTask(ServiceTask):
 
     https://cloudnull.github.io/directord/orchestrations.html#orchestration-library-usage
 
-    Execute a set of jobs against a director cluster. Execution returns a
+    Execute a set of jobs against a directord cluster. Execution returns a
     byte encoded list of jobs UUID.
 
     :returns: List
     """
 
-    class DirectorArgs:  # pylint: disable=too-few-public-methods
-        """Arguments required to interface with Director."""
+    class DirectordArgs:  # pylint: disable=too-few-public-methods
+        """Arguments required to interface with Directord."""
 
         debug = False
         socket_path = "/var/run/directord.sock"
@@ -113,8 +113,8 @@ class DirectordTask(ServiceTask):
             self.data,
         )
 
-        _mixin = mixin.Mixin(args=self.DirectorArgs)
-        _user = user.Manage(args=self.DirectorArgs)
+        _mixin = mixin.Mixin(args=self.DirectordArgs)
+        _user = user.Manage(args=self.DirectordArgs)
 
         try:
             jobs = _mixin.exec_orchestrations(
@@ -138,7 +138,7 @@ class DirectordTask(ServiceTask):
                 LOG.error(info)
                 success = False
         if not success:
-            raise ExecutionFailed("Director job execution failed")
+            raise ExecutionFailed("Directord job execution failed")
         return [TaskResult(success, {})]
 
 

--- a/task_core/tests/test_tasks.py
+++ b/task_core/tests/test_tasks.py
@@ -24,7 +24,7 @@ jobs:
   - echo: "service a run"
 """
 
-DUMMY_DIRECTOR_SERVICE_TASK_DATA = """
+DUMMY_DIRECTORD_SERVICE_TASK_DATA = """
 id: setup
 action: run
 provides:
@@ -105,7 +105,7 @@ class TestDirectordTask(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        self.data = yaml.safe_load(DUMMY_DIRECTOR_SERVICE_TASK_DATA)
+        self.data = yaml.safe_load(DUMMY_DIRECTORD_SERVICE_TASK_DATA)
 
     def test_object(self):
         """test basic object"""
@@ -117,9 +117,8 @@ class TestDirectordTask(unittest.TestCase):
         self.assertEqual(obj.action, "run")
         self.assertEqual(obj.jobs, self.data["jobs"])
 
-    @mock.patch("directord.user.Manage")
     @mock.patch("directord.mixin.Mixin")
-    def test_execute(self, mock_mixin, mock_manage):
+    def test_execute(self, mock_mixin):
         """test execute"""
         obj = tasks.DirectordTask("foo", self.data, ["host-a", "host-b"])
         result = obj.execute()


### PR DESCRIPTION
Sadly the director name was already taken on pypi and there
was no way I could assume the director project name, even
though there's been no work on it pushlished since 2009.
This PR renames the Director project to "Directord" and
changes the install from the git source to using the pypi
published package.

* https://pypi.org/project/directord

Signed-off-by: Kevin Carter <kecarter@redhat.com>