### PR TITLE
Add release workflow to automatically create RPMs

### DIFF
--- a/.github/workflows/py-tox.yml
+++ b/.github/workflows/py-tox.yml
@@ -2,7 +2,7 @@
 
 name: py-tox
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
@@ -40,3 +40,10 @@ jobs:
     - name: Run coverage
       run: |
         tox -e coverage
+
+  container_build_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build new task-core container
+      run: docker build -t task-core -f contrib/container-build/Containerfile .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+
+name: Task-Core release
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  pypi_push_and_publish:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out the repo
+      uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+    - name: Build the python package
+      run: |
+        python3 -m pip install --upgrade pip
+        python3 -m pip install --upgrade twine build wheel setuptools
+        python3 -m build --no-isolation
+    # NOTE: Used for automatic pushes to pypi
+    # Enable when the PYPI token is stored as a secret within github.
+    # - name: Publish a Python distribution to PyPI
+    #   uses: pypa/gh-action-pypi-publish@release/v1
+    #   with:
+    #     user: __token__
+    #     password: ${{ secrets.PYPI_API_TOKEN }}
+    #     skip_existing: true
+    # - name: Release
+    #   uses: softprops/action-gh-release@v1
+    #   if: startsWith(github.ref, 'refs/tags/')
+    #   with:
+    #     files: dist/task*
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: build RPM package
+      id: rpm
+      uses: naveenrajm7/rpmbuild@master
+      with:
+        spec_file: "contrib/task-core.spec"
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: Binary RPM
+        path: ${{ steps.rpm.outputs.rpm_dir_path }}

--- a/contrib/task-core.spec
+++ b/contrib/task-core.spec
@@ -38,7 +38,7 @@ Requires:       python3-stevedore
 Requires:       python3-taskflow
 Requires:       python3-yaml
 # these are backends
-Recommends:     directord
+Recommends:     python3dist(directord)
 Recommends:     python3-ansible-runner
 
 %{?python_provide:%python_provide python3-%{name}}


### PR DESCRIPTION
When a release is cut this change will now automatically create an RPM
and upload it to the local github artifact cache.

> a stub has been added so that we can also enable automatic pushes to
  PYPI. This will require a PYPI API token stored in github before it
  can be activated.

Signed-off-by: Kevin Carter <kecarter@redhat.com>